### PR TITLE
Add support for audio tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Next include `angular`, `video.js`, the `vjs-video` directive and it's correspon
 
 ## Basic usage
 
-The `vjs-video` directive is designed to be non-invasive; to use it, include `vjs-video` as a dependency and add the directive to a video tag styled for `video.js`.
+The `vjs-video` directive is designed to be non-invasive; to use it, include `vjs-video` as a dependency and add the directive to a video or audio tag styled for `video.js`.
 
 
 First include `vjs-video` as a dependency within your angular app:
@@ -55,7 +55,7 @@ angular.module('app', [ 'vjs.video']);
 
 ```
 
-Next, add the `vjs-video` directive to a video tag styled for `video.js`:
+Next, add the `vjs-video` directive to a video or audio tag styled for `video.js`:
 
 ```html
 <video class="video-js vjs-default-skin" controls preload="auto"
@@ -80,9 +80,9 @@ The following example wraps a `video.js` instance within a responsive container 
 </vjs-video-container>
 ```
 
-> When using `vjs-video-container` be sure to attach all the directive attributes (such as `vjs-setup` or `vjs-media`) to the `vjs-video-container` element rather than on the enclosed video tag. The attributes only should be attached when using in conjunction with the `vjs-video` directive on a video tag.
+> When using `vjs-video-container` be sure to attach all the directive attributes (such as `vjs-setup` or `vjs-media`) to the `vjs-video-container` element rather than on the enclosed video or audio tag. The attributes only should be attached when using in conjunction with the `vjs-video` directive on a video or audio tag.
 
-> Also, make sure you never mix usage of `vjs-video-container` with `vjs-video`. The `vjs-video` directive accepts the same directive attributes but shouldn't be used if a video tag is wrapped inside of a `vjs-video-container`.
+> Also, make sure you never mix usage of `vjs-video-container` with `vjs-video`. The `vjs-video` directive accepts the same directive attributes but shouldn't be used if a video or audio tag is wrapped inside of a `vjs-video-container`.
 
 ## Directive Attributes
 

--- a/app/scripts/directives/vjs.directive.js
+++ b/app/scripts/directives/vjs.directive.js
@@ -32,7 +32,7 @@
             }
 
             if (isContainer) {
-                videos = element[0].getElementsByTagName('video');
+                videos = element[0].querySelectorAll('video, audio');
                 if (videos.length === 0) {
                     throw new Error('video tag must be defined within container directive!');
                 } else if (videos.length > 1) {
@@ -359,7 +359,7 @@
                 var vid,
                     origContent,
                     mediaChangedHandler = function (e) {
-                        var vidEl = element[0].querySelector('video');
+                        var vidEl = element[0].querySelector('video, audio');
 
                         if (vidEl) {
                             //remove any inside contents

--- a/app/scripts/directives/vjs.directive.js
+++ b/app/scripts/directives/vjs.directive.js
@@ -16,6 +16,10 @@
                 window.videojs.VERSION : '0.0.0';
     }
 
+    function isMediaElement(element) {
+        return element[0].nodeName === 'VIDEO' || element[0].nodeName === 'AUDIO';
+    }
+
     module.controller('VjsVideoController', ['$scope', function ($scope) {
         var self = this;
 
@@ -37,10 +41,10 @@
 
                 vid = videos[0];
             } else {
-                if (element[0].nodeName === 'VIDEO') {
+                if (isMediaElement(element)) {
                     vid = element[0];
                 } else {
-                    throw new Error('directive must be attached to a video tag!');
+                    throw new Error('directive must be attached to a video or audio tag!');
                 }
             }
 
@@ -190,7 +194,7 @@
             var opts = params.vjsSetup || {},
                 ratio = params.vjsRatio,
                 isValidContainer =
-                    ((element[0].nodeName !== 'VIDEO') && !getVersion().match(/^5\./)) ? true : false,
+                    (!isMediaElement(element) && !getVersion().match(/^5\./)) ? true : false,
                 mediaWatcher;
 
             if (!window.videojs) {

--- a/test/spec/directives/vjs.directive.js
+++ b/test/spec/directives/vjs.directive.js
@@ -17,8 +17,10 @@ describe('Directive: vjs.directive.js', function () {
         vidElementContainerVjsSetupStr = "<vjs-video-container><video vjs-setup></video></vjs-video-container>",
         vidElementContainerVjsMediaStr = "<vjs-video-container><video vjs-media></video></vjs-video-container>",
         vidElementContainerVjsRatioStr = "<vjs-video-container><video vjs-ratio></video></vjs-video-container>",
+        audioContainerStr = "<div vjs-video-container><audio></audio></div>",
         nonVidContainerStr = "<div vjs-video-container></div>",
         multVidsContainerStr = "<div vjs-video-container><video></video><video></video></div>",
+        multMixedContainerStr = "<div vjs-video-container><video></video><audio></audio></div>",
         vidContainerWithDimsStr = "<div vjs-video-container><video id='vid-dim' width='320' height='320'></video></div>",
         vidRatioCharStr = "<div vjs-video-container vjs-ratio='asdf'><video></video></div>",
         vidRatioInvalidStr = "<div vjs-video-container vjs-ratio='1920:1080:720'><video></video></div>",
@@ -260,10 +262,22 @@ describe('Directive: vjs.directive.js', function () {
             }).throws(Error, 'only one video can be defined within the container directive!');
         });
 
+        it('should throw an error if container defines more than one media tag', function () {
+            expect(function () {
+                compileAndLink(multMixedContainerStr, scope);
+            }).throws(Error, 'only one video can be defined within the container directive!');
+        });
+
         it('should attach videojs to the video tag', function () {
             //videojs should add at vjs-tech class to the element
             var el = compileAndLink(vidContainerStr, scope);
             expect(el.find('video').hasClass('vjs-tech')).to.be.true;
+        });
+
+        it('should attach videojs to the audio tag', function () {
+            //videojs should add at vjs-tech class to the element
+            var el = compileAndLink(audioContainerStr, scope);
+            expect(el.find('audio').hasClass('vjs-tech')).to.be.true;
         });
 
         it('should register as the vjs-video-container element', function () {

--- a/test/spec/directives/vjs.directive.js
+++ b/test/spec/directives/vjs.directive.js
@@ -9,6 +9,7 @@ describe('Directive: vjs.directive.js', function () {
     var vidStr = "<video vjs-video></video>",
         vidWithIdStr = "<video id='vidId' vjs-video></video>",
         multipleVidStr = "<div><video vjs-video></video><video vjs-video></video></div>",
+        audioStr = "<audio vjs-video></audio>",
         nonVidStr = "<div vjs-video>",
         vidContainerStr = "<div vjs-video-container><video></video></div>",
         vidElementContainerStr = "<vjs-video-container><video></video></vjs-video-container>",
@@ -47,6 +48,12 @@ describe('Directive: vjs.directive.js', function () {
         it('should attach videojs to the video tag', function () {
             //videojs should add at vjs-tech class to the element
             var el = compileAndLink(vidStr, scope);
+            expect(el.hasClass('vjs-tech')).to.be.true;
+        });
+
+        it('should attach videojs to the audio tag', function () {
+            //videojs should add at vjs-tech class to the element
+            var el = compileAndLink(audioStr, scope);
             expect(el.hasClass('vjs-tech')).to.be.true;
         });
 


### PR DESCRIPTION
This adds support for using the `vjs-video` and `vjs-video-container` directives with audio tags. Video.js has supported audio tags since v4.9.

Let me know if there's anything you'd like me to change.
