### PR TITLE
Video.js 5 bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,9 +12,10 @@
   },
   "dependencies": {
     "angular": "^1.3.0",
-    "video.js": "~4.12.13"
+    "video.js": "4.12.13 - 5"
   },
   "devDependencies": {
+    "video.js": "~4.12.13",
     "jquery": "~2.1.4",
     "angular-mocks": "^1.3.0",
     "sinonjs": "~1.14.1",


### PR DESCRIPTION
This will set Video.js versions from 4.12.13 through the latest 5.x release as valid dependencies. This will  set 5.x as the default for downstream projects, while still using 4.x for dev, to satisfy the tests.

This will prevent conflicts during bower install when using vjs-video in a project with Video.js 5.
