### PR TITLE
bug-75-videojs-contrib-ads-loadstart-event

### DIFF
--- a/app/scripts/directives/vjs.directive.js
+++ b/app/scripts/directives/vjs.directive.js
@@ -243,19 +243,21 @@
             );
 
             //bootstrap videojs
-            videojs(vid, opts, function () {
+            var player = videojs(vid, opts, function () {
                 if (isValidContainer) {
                     applyRatio(element, ratio);
                 }
+            });
 
+            if(player){
                 //emit ready event with reference to video
                 $scope.$emit('vjsVideoReady', {
                     id: vid.getAttribute('id'),
-                    vid: this,
-                    player: this,
-                    controlBar: this.controlBar
+                    vid: player,
+                    player: player,
+                    controlBar: player.controlBar
                 });
-            });
+            }
 
             //dispose of videojs before destroying directive
             $scope.$on('$destroy', function () {


### PR DESCRIPTION
Fix #75

Reference to this issue googleads/videojs-ima#424 that i fixed "videojs-contrib-ads has not seen a loadstart event 5 seconds."

Old Implementation
![old-implementation](https://user-images.githubusercontent.com/15931045/31264239-20b77a84-aa81-11e7-83bb-501b01939fd2.jpg)

New Implementation
![new-implementation](https://user-images.githubusercontent.com/15931045/31264243-27668bea-aa81-11e7-9ca2-3c7a346ef1ee.jpg)

